### PR TITLE
fix: `--tsconfig` parameter crashed Node and wasn't respected on type generation

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -41,7 +41,7 @@ program
   .option("-t, --target <target>", "ECMAScript featureset to target (default: ESNext).")
   .option("-f, --format <format>", "Output format (default: ESM).")
   .option("-b, --bundle", "Bundle external dependencies into entrypoints.")
-  .option("-t, --tsconfig", "Specify a custom tsconfig.json file.", "tsconfig.json")
+  .option("-t, --tsconfig <file>", "Specify a custom tsconfig.json file.", "tsconfig.json")
   .option("-e, --external <external...>", "External dependencies to exclude from bundling.")
   .option("--binary", "Build binary executables from src/bin.ts.")
   .option("--standalone", "Bundle a standalone entry-points without any import statements (disables splitting).")

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -495,7 +495,7 @@ export const build = async (options: BuildArgs = {}) => {
 
   if (!runtimeOnly) {
     await showProgress(
-      async () => await emitTsDeclarations(),
+      async () => await emitTsDeclarations(tsconfig),
       {
         start: "Generating type declarations.",
         success: `Generated declarations for ${allFiles.length} files.`,

--- a/src/commands/build/lib/emitTsDeclarations.ts
+++ b/src/commands/build/lib/emitTsDeclarations.ts
@@ -9,7 +9,7 @@ export const EMIT_DTS_OVERRIDES = {
   noEmit: false,
 };
 
-export const emitTsDeclarations = async () => {
+export const emitTsDeclarations = async (tsconfig: string) => {
   const DEBUG = createDebugLogger(emitTsDeclarations);
   const shell = createShell({
     log: false,
@@ -22,7 +22,7 @@ export const emitTsDeclarations = async () => {
       .map(([key, value]) => `--${key} ${value}`)
       .join(" ");
 
-  const cmd = `pnpm tsc -p tsconfig.json ${argString}`;
+  const cmd = `pnpm tsc -p ${tsconfig} ${argString}`;
   DEBUG.log(`Calling: ${cmd}`);
   await shell.run(cmd);
 };


### PR DESCRIPTION
This PR fixes two issues (I thought there was one, but writing a test proved that it didn't behave as expected after initial fix)

First, is that Node crashes with a weird error if you try to run `tsmodule --tsconfig literarlly_anything`:

```
TypeError: t.replace is not a function
    at rn (./node_modules/@tsmodule/tsmodule/dist/bin.js:44:186)
    at cp (./node_modules/@tsmodule/tsmodule/dist/bin.js:46:10003)
    at St (./node_modules/@tsmodule/tsmodule/dist/bin.js:55:917)
    at async Ip (./node_modules/@tsmodule/tsmodule/dist/bin.js:55:5043)
    at async cr.<anonymous> (./node_modules/@tsmodule/tsmodule/dist/bin.js:55:9966)
```

I couldn't get my head around where this could possibly come from until I noticed an incorrect `.option` commander call - you didn't specify that `-t, --tsconfig` is an option that expects a parameter.

Second, fixing that, it turned out that type generation, the one thing I actually care about for `--tsconfig` call, wasn't respecting it at all, instead using a hardcoded `tsconfig.json`.

This PR includes a test to validate both of these fixes.
